### PR TITLE
Implement Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/TF2 Rich Presence/build.py
+++ b/TF2 Rich Presence/build.py
@@ -291,10 +291,7 @@ def main(version_num='v2.1.1'):
         python_target = os.path.abspath(Path(f'{new_build_folder_name}/resources/{interpreter_name}'))
         print(f"Copying from {python_source}\n\tto {python_target}: ", end='')
         assert os.path.isdir(python_source) and not os.path.isdir(python_target)
-        if sys.platform == 'win32':
-            subprocess.run(f'xcopy \"{python_source}\" \"{python_target}\\\" /E /Q')
-        else:
-            raise SyntaxError("Whatever the Linux/MacOS equivalent of xcopy is")
+        subprocess.run(f'xcopy \"{python_source}\" \"{python_target}\\\" /E /Q')
     elif os.path.isfile(python_source_zip):
         python_target = os.path.abspath(Path(f'{new_build_folder_name}/resources'))
         print(f"Extracting from {python_source_zip}\n\tto {python_target}")
@@ -490,10 +487,7 @@ def copy_dir(source, target):
         pass
 
     print(f"Copying from {source} to {target}: ", end='')
-    if sys.platform == 'win32':
-        subprocess.run(f'xcopy \"{source}\" \"{target}{os.path.sep}\" /E /Q')
-    else:
-        raise SyntaxError("Whatever the Linux/MacOS equivalent of xcopy is")
+    subprocess.run(f'xcopy \"{source}\" \"{target}{os.path.sep}\" /E /Q')
 
 
 # log all prints to a file
@@ -515,4 +509,7 @@ class Logger(object):
 
 
 if __name__ == '__main__':
-    main()
+    if os.name == 'nt':
+        main()
+    else:
+        print("Build is not available on non Windows systems")

--- a/TF2 Rich Presence/gui.py
+++ b/TF2 Rich Presence/gui.py
@@ -399,9 +399,13 @@ class GUI(tk.Frame):
         self.launch_tf2_button['text'] = self.loc.text("Launching...")
         self.safe_update()
 
+        kwargs = {}
+        if os.name == "nt":
+            kwargs["creationflags"] = 0x08000000
+
         if self.tf2_launch_cmd:
             self.launched_tf2_with_button = True
-            subprocess.Popen(f'"{self.tf2_launch_cmd[0]}" {self.tf2_launch_cmd[1]} -game tf -steam -secure -condebug -conclearlog', creationflags=0x08000000)
+            subprocess.Popen(list(self.tf2_launch_cmd) + ["-game",  "tf", "-steam", "-secure", "-condebug", "-conclearlog"], **kwargs)
         else:
             messagebox.showerror(self.loc.text("TF2 Rich Presence"), self.loc.text("Couldn't find a Team Fortress 2 installation."))
             self.launch_tf2_button['state'] = 'normal'

--- a/TF2 Rich Presence/localization.py
+++ b/TF2 Rich Presence/localization.py
@@ -2,7 +2,6 @@
 # https://github.com/Kataiser/tf2-rich-presence/blob/master/LICENSE
 # cython: language_level=3
 
-import ctypes
 import functools
 import json
 import locale
@@ -119,7 +118,7 @@ def detect_system_language(log: logger.Log):
 
     if not db['has_asked_language']:
         language_codes: dict = {read_localization_files()[lang]['code']: lang for lang in langs[1:]}
-        system_locale: str = locale.windows_locale[ctypes.windll.kernel32.GetUserDefaultUILanguage()]
+        system_locale: str = locale.getlocale()[0]
         system_language_code: str = system_locale.split('_')[0]
         is_brazilian_port: bool = system_locale == 'pt_BR'
 

--- a/TF2 Rich Presence/logger.py
+++ b/TF2 Rich Presence/logger.py
@@ -22,6 +22,11 @@ import settings
 import utils
 
 
+if os.name == "nt":
+    APPDATA = os.getenv('APPDATA')
+else:
+    APPDATA = os.path.join(os.getenv("HOME"), ".config")
+
 # TODO: replace this whole thing with a real logger
 class Log:
     def __init__(self, path: Optional[str] = None):
@@ -30,11 +35,10 @@ class Log:
             self.logs_path: str = 'logs'
             created_logs_dir: bool = False
         else:
-            self.logs_path = os.path.join(os.getenv('APPDATA'), 'TF2 Rich Presence', 'logs')
+            self.logs_path = os.path.join(APPDATA, 'TF2 Rich Presence', 'logs')
 
             if not os.path.isdir(self.logs_path):
-                os.mkdir(os.path.join(os.getenv('APPDATA'), 'TF2 Rich Presence'))
-                os.mkdir(self.logs_path)
+                os.makedirs(self.logs_path)
                 time.sleep(0.1)  # ensure it gets created
                 created_logs_dir = True
             else:

--- a/TF2 Rich Presence/main.py
+++ b/TF2 Rich Presence/main.py
@@ -343,8 +343,9 @@ class TF2RichPresense:
         if not self.has_set_process_priority:
             self_process: psutil.Process = psutil.Process()
             priorities_before: tuple = (self_process.nice(), self_process.ionice())
-            self_process.nice(psutil.BELOW_NORMAL_PRIORITY_CLASS)
-            self_process.ionice(psutil.IOPRIO_LOW)
+            if os.name == "nt":
+                self_process.nice(psutil.BELOW_NORMAL_PRIORITY_CLASS)
+                self_process.ionice(psutil.IOPRIO_LOW)
             priorities_after: tuple = (self_process.nice(), self_process.ionice())
             self.log.debug(f"Set process priorities from {priorities_before} to {priorities_after}")
             self.has_set_process_priority = True
@@ -489,4 +490,7 @@ class TF2RichPresense:
 
 
 if __name__ == '__main__':
-    launch()
+    try:
+        launch()
+    except KeyboardInterrupt:
+        pass

--- a/TF2 Rich Presence/settings.py
+++ b/TF2 Rich Presence/settings.py
@@ -4,7 +4,10 @@
 
 import functools
 import json
-import winreg
+try:
+    import winreg
+except ImportError:
+    import unixreg as winreg
 from typing import Optional, Union
 
 import logger

--- a/TF2 Rich Presence/utils.py
+++ b/TF2 Rich Presence/utils.py
@@ -11,6 +11,10 @@ import os
 import threading
 from typing import Any, Callable, Dict, Optional, Union
 
+if os.name == "nt":
+    APPDATA = os.getenv('APPDATA')
+else:
+    APPDATA = os.path.join(os.getenv("HOME"), ".config")
 
 # read from or write to DB.json (intentionally uncached)
 def access_db(write: dict = None, pass_permission_error: bool = True) -> Optional[Dict[str, Union[bool, list, str]]]:
@@ -52,8 +56,8 @@ def access_db(write: dict = None, pass_permission_error: bool = True) -> Optiona
 
 @functools.cache
 def db_json_path() -> str:
-    if os.path.isdir(os.path.join(os.getenv('APPDATA'), 'TF2 Rich Presence')):
-        return os.path.join(os.getenv('APPDATA'), 'TF2 Rich Presence', 'DB.json')
+    if os.path.isdir(os.path.join(APPDATA, 'TF2 Rich Presence')):
+        return os.path.join(APPDATA, 'TF2 Rich Presence', 'DB.json')
     else:
         return 'DB.json'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests==2.27.1
 sentry_sdk==1.5.2
 urllib3==1.26.8
 vdf==3.4
+unixreg; sys_platform != 'win32'


### PR DESCRIPTION
late followup to #55
closes #43 

- Windows specific logic has been gated behind an if case
- APPDATA has been globalized in many cases to reduce calls to os.getenv as well as to use $HOME/.config on non NT systems
- a dependency on a posix compatibility layer for winreg has been added for non Windows systems
  - no need to rewrite huge chunks of the code
  - has been written specificially for this purpose

Things to implement before this can be merged:
- [x] game detection
- [ ] Steam Username detection
  - there seems to be no reliable way to detect the current steam username so we just use the users name so its still unique. Most people won't have more than 1 account either way
- [ ] building on Linux
  - building is a huge mess and its best to not do this on Linux at all since distros all have ship different libraries and deal with them differently 